### PR TITLE
アルバム一覧表示の実装

### DIFF
--- a/app/assets/javascripts/images.coffee
+++ b/app/assets/javascripts/images.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/_users-index.scss
+++ b/app/assets/stylesheets/_users-index.scss
@@ -44,7 +44,7 @@
   padding-top: 40px;
   font-size: 25px;
   
-  .album__display {
+  .group__display {
     width: 70%;
     height: 100vh;
     margin: 0 auto;

--- a/app/assets/stylesheets/_users-index.scss
+++ b/app/assets/stylesheets/_users-index.scss
@@ -28,13 +28,6 @@
       color: black;
     }
   }
-  .main__menu__group-show {
-    font-size: 18px;
-    .group__show {
-      text-decoration: none;
-      color: black;
-    }
-  }
   .main__menu__logout {
     font-size: 18px;
     .logout__mypage {

--- a/app/assets/stylesheets/images.scss
+++ b/app/assets/stylesheets/images.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the images controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -1,8 +1,5 @@
-class ImagesController < ApplicationController
+class AlbumsController < ApplicationController
   before_action :set_group
-
-  def index
-    @images = @group.images.includes(:user)
 
   def new
     @image = Image.new
@@ -16,9 +13,6 @@ class ImagesController < ApplicationController
       flash.now[:alert] = '写真を登録してください'
       render :new
     end
-  end
-
-  def show
   end
 
   private

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -14,6 +14,10 @@ def create
   end
 end
 
+def show
+  
+end
+
 private
 def group_params
   params.require(:group).permit(:name, user_ids: [])

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,0 +1,2 @@
+class ImagesController < ApplicationController
+end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,2 +1,32 @@
 class ImagesController < ApplicationController
+  before_action :set_group
+
+  def index
+    @images = @group.images.includes(:user)
+
+  def new
+    @image = Image.new
+  end
+
+  def create
+    @imege = @group.images.new(image_params)
+    if @image.save
+      redirect_to users_path
+    else
+      flash.now[:alert] = '写真を登録してください'
+      render :new
+    end
+  end
+
+  def show
+  end
+
+  private
+  def image_params
+    params.require(:image).permit(:picture, :content, :date).merge(user_id: current_user.id)
+  end
+
+  def set_group
+    @group = Group.find(params[:group_id])
+  end
 end

--- a/app/helpers/images_helper.rb
+++ b/app/helpers/images_helper.rb
@@ -1,0 +1,2 @@
+module ImagesHelper
+end

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,5 +1,6 @@
-class Image < ApplicationRecord
+class Album < ApplicationRecord
   belongs_to :user
   belongs_to :group
+  has_many :pictures, dependent: :destroy
   validates :picture, presence: true
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,6 @@
 class Group < ApplicationRecord
   has_many :group_users
   has_many :users, through: :group_users
+  has_many :albums, dependent: :destroy
   validates :name, presence: true, uniqueness: true
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,0 +1,2 @@
+class Image < ApplicationRecord
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,2 +1,5 @@
 class Image < ApplicationRecord
+  belongs_to :user
+  belongs_to :group
+  validates :picture, presence: true
 end

--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -1,0 +1,3 @@
+class Picture < ApplicationRecord
+  belongs_to :album
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,5 +6,6 @@ class User < ApplicationRecord
 
   has_many :group_users
   has_many :groups, through: :group_users
+  has_many :albums
   validates :name, presence: true, uniqueness: true
 end

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -16,5 +16,9 @@
 .main-content
   アルバム一覧
   .album__display
-    
-    
+    - current_user.groups.each do |group|
+      %ul.group__list
+        = link_to '#' do
+          %li.group__list__name
+            = group.name
+          %li.group__list__image

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -14,11 +14,10 @@
     = link_to destroy_user_session_path, method: :delete, class: 'logout__mypage' do
       ログアウト
 .main-content
-  アルバム一覧
-  .album__display
+  グループ一覧
+  .group__display
     - current_user.groups.each do |group|
       %ul.group__list
         = link_to '#' do
           %li.group__list__name
             = group.name
-          %li.group__list__image

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -10,14 +10,11 @@
     = link_to new_group_path, class: 'group__make' do
       グループを作る
   %p ｜
-  .main__menu__group-show
-    = link_to '#', class: 'group__show' do
-      グループ一覧
-  %p ｜
   .main__menu__logout
     = link_to destroy_user_session_path, method: :delete, class: 'logout__mypage' do
       ログアウト
 .main-content
   アルバム一覧
   .album__display
+    
     

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   
   resources :users, only: [:index, :show]
   resources :groups, only: [:new, :create]
-    resources :messages, only: [:index, :new, :create, :show]
+    resources :albums, only: [:new, :create]
   root 'tops#index'
   
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   
   resources :users, only: [:index, :show]
   resources :groups, only: [:new, :create]
+    resources :messages, only: [:index, :new, :create, :show]
   root 'tops#index'
   
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/db/migrate/20200705011310_create_images.rb
+++ b/db/migrate/20200705011310_create_images.rb
@@ -1,0 +1,8 @@
+class CreateImages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :images do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200705011310_create_images.rb
+++ b/db/migrate/20200705011310_create_images.rb
@@ -1,7 +1,10 @@
 class CreateImages < ActiveRecord::Migration[5.2]
   def change
     create_table :images do |t|
-
+      t.string :picture, null: false
+      t.text :content
+      t.references :user, foreign_key: true
+      t.references :group, foreign_key: true
       t.timestamps
     end
   end

--- a/db/migrate/20200705070155_add_date_to_images.rb
+++ b/db/migrate/20200705070155_add_date_to_images.rb
@@ -1,0 +1,5 @@
+class AddDateToImages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :images, :date, :date
+  end
+end

--- a/db/migrate/20200705133951_change_images_to_albums.rb
+++ b/db/migrate/20200705133951_change_images_to_albums.rb
@@ -1,0 +1,5 @@
+class ChangeImagesToAlbums < ActiveRecord::Migration[5.2]
+  def change
+    rename_table :images, :albums
+  end
+end

--- a/db/migrate/20200706095253_remove_picture_from_albums.rb
+++ b/db/migrate/20200706095253_remove_picture_from_albums.rb
@@ -1,0 +1,5 @@
+class RemovePictureFromAlbums < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :albums, :picture, :string
+  end
+end

--- a/db/migrate/20200706095647_create_pictures.rb
+++ b/db/migrate/20200706095647_create_pictures.rb
@@ -1,0 +1,9 @@
+class CreatePictures < ActiveRecord::Migration[5.2]
+  def change
+    create_table :pictures do |t|
+      t.string :image, null: false
+      t.references :album, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200706102218_add_default_to_group_users.rb
+++ b/db/migrate/20200706102218_add_default_to_group_users.rb
@@ -1,0 +1,6 @@
+class AddDefaultToGroupUsers < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :group_users, :group_id, false
+    change_column_null :group_users, :user_id, false
+  end
+end

--- a/db/migrate/20200706103309_add_default_to_albums.rb
+++ b/db/migrate/20200706103309_add_default_to_albums.rb
@@ -1,0 +1,6 @@
+class AddDefaultToAlbums < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :albums, :group_id, false
+    change_column_null :albums, :user_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_04_075423) do
+ActiveRecord::Schema.define(version: 2020_07_05_070155) do
 
   create_table "group_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "group_id"
@@ -28,6 +28,18 @@ ActiveRecord::Schema.define(version: 2020_07_04_075423) do
     t.index ["name"], name: "index_groups_on_name", unique: true
   end
 
+  create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "picture", null: false
+    t.text "content"
+    t.bigint "user_id"
+    t.bigint "group_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.date "date"
+    t.index ["group_id"], name: "index_images_on_group_id"
+    t.index ["user_id"], name: "index_images_on_user_id"
+  end
+
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", default: "", null: false
@@ -43,4 +55,6 @@ ActiveRecord::Schema.define(version: 2020_07_04_075423) do
   end
 
   add_foreign_key "group_users", "groups"
+  add_foreign_key "images", "groups"
+  add_foreign_key "images", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_05_070155) do
+ActiveRecord::Schema.define(version: 2020_07_06_103309) do
+
+  create_table "albums", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.text "content"
+    t.bigint "user_id", null: false
+    t.bigint "group_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.date "date"
+    t.index ["group_id"], name: "index_albums_on_group_id"
+    t.index ["user_id"], name: "index_albums_on_user_id"
+  end
 
   create_table "group_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "group_id"
-    t.bigint "user_id"
+    t.bigint "group_id", null: false
+    t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["group_id"], name: "index_group_users_on_group_id"
@@ -28,16 +39,12 @@ ActiveRecord::Schema.define(version: 2020_07_05_070155) do
     t.index ["name"], name: "index_groups_on_name", unique: true
   end
 
-  create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "picture", null: false
-    t.text "content"
-    t.bigint "user_id"
-    t.bigint "group_id"
+  create_table "pictures", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "image", null: false
+    t.bigint "album_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.date "date"
-    t.index ["group_id"], name: "index_images_on_group_id"
-    t.index ["user_id"], name: "index_images_on_user_id"
+    t.index ["album_id"], name: "index_pictures_on_album_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -54,7 +61,8 @@ ActiveRecord::Schema.define(version: 2020_07_05_070155) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "albums", "groups"
+  add_foreign_key "albums", "users"
   add_foreign_key "group_users", "groups"
-  add_foreign_key "images", "groups"
-  add_foreign_key "images", "users"
+  add_foreign_key "pictures", "albums"
 end

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ImagesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/images.yml
+++ b/test/fixtures/images.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/pictures.yml
+++ b/test/fixtures/pictures.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ImageTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/picture_test.rb
+++ b/test/models/picture_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PictureTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
アルバム一覧表示の実装
# Why
ユーザーマイページに登録したグループの一覧を表示し、グループ名をクリックすることによって、グループで投稿したアルバムを一覧表示する機能を構築することで、ユーザーが登録したグループとその写真を管理しやすくするため。